### PR TITLE
Do not clobber F5

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,7 @@
-By default, |:CheckSyntax| is mapped to <F5>. The |:CheckSyntax| command 
-takes one optional argument: the mode (default: &filetype). The 
-following modes are pre-defined (and maybe some more):
+By default, |:CheckSyntax| is mapped to <F5> (if not mapped already), and
+automatically executed when saving the buffer.
+The |:CheckSyntax| command takes one optional argument: the mode (default:
+&filetype). The following modes are pre-defined (and maybe some more):
 
     c, cpp :: Check syntax via splint
     html :: Check syntax via tidy

--- a/plugin/checksyntax.vim
+++ b/plugin/checksyntax.vim
@@ -38,7 +38,7 @@ command! -bang -nargs=? CheckSyntax call checksyntax#Check(1, "<bang>", <f-args>
 
 
 " @TPluginInclude
-if !hasmapto(':CheckSyntax')
+if !hasmapto(':CheckSyntax') && empty(maparg('<F5>', 'n'))
     noremap <F5> :CheckSyntax<cr>
     inoremap <F5> <c-o>:CheckSyntax<cr>
 endif


### PR DESCRIPTION
An alternative would be to not map `F5` if auto-checking is enabled
(which it is by default).
Manually calling CheckSyntax appears to be not that useful; it is most
useful after saving, and then done automatically at best.
