### PR TITLE
force php to display errors, even when in production mode

### DIFF
--- a/autoload/checksyntax.vim
+++ b/autoload/checksyntax.vim
@@ -43,7 +43,7 @@ endif
 if !exists('g:checksyntax.php')
     let g:checksyntax['php'] = {
                 \ 'auto': executable('php') == 1,
-                \ 'cmd': 'php -l',
+                \ 'cmd': 'php -l -d error_reporting=E_PARSE -d display_errors=1',
                 \ 'efm': '%*[^:]: %m in %f on line %l',
                 \ 'okrx': 'No syntax errors detected in ',
                 \ 'alt': 'phpp'


### PR DESCRIPTION
Production PHP configurations typically prevent errors from being sent to output by setting the `error_reporting` and `display_errors` INI settings.

This commit forces the php lint check to display all syntax errors.
