### PR TITLE
Close issue #7 - duplicate PHP errors

### DIFF
--- a/autoload/checksyntax.vim
+++ b/autoload/checksyntax.vim
@@ -73,7 +73,7 @@ endif
 if !exists('g:checksyntax.php')
     let g:checksyntax['php'] = {
                 \ 'auto': executable('php') == 1,
-                \ 'cmd': 'php -l -d error_reporting=E_PARSE -d display_errors=1',
+                \ 'cmd': 'php -l -d error_reporting=E_PARSE',
                 \ 'efm': '%*[^:]: %m in %f on line %l',
                 \ 'okrx': 'No syntax errors detected in ',
                 \ 'alt': 'phpp'


### PR DESCRIPTION
Test PHP file:
    <?php blah(;

php -l test.php works as expected.  When you use php -l -d display_errors=1, the warnings get duplicated.
