### PR TITLE
Add flake8 for checking python syntax and fix the bug that 'preferred' is not honored

### DIFF
--- a/autoload/checksyntax.vim
+++ b/autoload/checksyntax.vim
@@ -607,7 +607,7 @@ function! s:GetValidAlternatives(filetype, run_alternatives, alternatives) "{{{3
             else
                 let valid[name] = alternative
             endif
-            if a:run_alternatives =~? '\<first\>'
+            if a:run_alternatives =~? '\<first\>' && !has_key(g:checksyntax#preferred, a:filetype)
                 break
             endif
         endif

--- a/autoload/checksyntax/defs/python.vim
+++ b/autoload/checksyntax/defs/python.vim
@@ -1,9 +1,15 @@
 " @Author:      Tom Link (mailto:micathom AT gmail com?subject=[vim])
 " @License:     GPL (see http://www.gnu.org/licenses/gpl.txt)
-" @Revision:    16
+" @Revision:    17
 
 
 call checksyntax#AddChecker('python?',
+            \   {
+            \     'cmd': 'flake8',
+            \     'if_executable': 'flake8',
+            \     'efm': '%f:%l:%c: %m',
+            \     'convert_filename': checksyntax#MaybeUseCygpath('flake8'),
+            \   },
             \   {
             \     'cmd': 'pyflakes',
             \     'if_executable': 'pyflakes',


### PR DESCRIPTION
In ```s:GetValidAlternatives()``` of autoload/checksyntax.vim, all checkers except the first one is skipped if run_alternatives is set to 'first', so the filter call in ```checksyntax#Check()```returns nothing if the preferred is not the actually one. I fix it by using a workaround in ```s:GetValidAlternatives()```. However, I'm not sure if it is semantically correct.