### PR TITLE
Add PHP_CodeSniffer checker for php.

### DIFF
--- a/autoload/checksyntax/defs/php.vim
+++ b/autoload/checksyntax/defs/php.vim
@@ -7,7 +7,6 @@ if !exists('g:checksyntax#defs#php#cmd')
     let g:checksyntax#defs#php#cmd = 'php'   "{{{2
 endif
 
-
 if !exists('g:checksyntax#defs#php#args')
     " Displaying errors for php files is surprisingly fragile since it 
     " depends on the php version and the php.ini file. If you get 
@@ -44,6 +43,24 @@ call checksyntax#AddChecker('php?',
             \     'if_executable': g:checksyntax#defs#php#cmd,
             \     'convert_filename': checksyntax#MaybeUseCygpath(g:checksyntax#defs#php#cmd),
             \     'efm': '%*[^:]: %m in %f on line %l',
+            \   }
+            \ )
+
+
+if !exists('g:checksyntax#defs#phpcs#cmd')
+    let g:checksyntax#defs#phpcs#cmd = 'phpcs'   "{{{2
+endif
+
+if !exists('g:checksyntax#defs#phpcs#args')
+    let g:checksyntax#defs#phpcs#args = ''   "{{{2
+endif
+
+call checksyntax#AddChecker('php?',
+            \   {
+            \     'name': 'phpcs',
+            \     'cmd': g:checksyntax#defs#phpcs#cmd .' --report=emacs '. g:checksyntax#defs#phpcs#args,
+            \     'if_executable': g:checksyntax#defs#phpcs#cmd,
+            \     'efm': '%f:%l:%*[^:]: %*[^-]- %m',
             \   }
             \ )
 

--- a/doc/checksyntax.txt
+++ b/doc/checksyntax.txt
@@ -145,8 +145,8 @@ Contents~
         g:checksyntax#defs#r#checkUsage_search_other_buffers ... |g:checksyntax#defs#r#checkUsage_search_other_buffers|
         g:checksyntax#defs#php#cmd ............................. |g:checksyntax#defs#php#cmd|
         g:checksyntax#defs#php#args ............................ |g:checksyntax#defs#php#args|
-        g:checksyntax#defs#phpcs#cmd ............................. |g:checksyntax#defs#phpcs#cmd|
-        g:checksyntax#defs#phpcs#args ............................ |g:checksyntax#defs#phpcs#args|
+        g:checksyntax#defs#phpcs#cmd ........................... |g:checksyntax#defs#phpcs#cmd|
+        g:checksyntax#defs#phpcs#args .......................... |g:checksyntax#defs#phpcs#args|
         g:checksyntax#defs#haxe#haxe ........................... |g:checksyntax#defs#haxe#haxe|
         g:checksyntax#defs#haxe#hxml_files ..................... |g:checksyntax#defs#haxe#hxml_files|
         checksyntax#defs#haxe#Gen .............................. |checksyntax#defs#haxe#Gen()|

--- a/doc/checksyntax.txt
+++ b/doc/checksyntax.txt
@@ -145,6 +145,8 @@ Contents~
         g:checksyntax#defs#r#checkUsage_search_other_buffers ... |g:checksyntax#defs#r#checkUsage_search_other_buffers|
         g:checksyntax#defs#php#cmd ............................. |g:checksyntax#defs#php#cmd|
         g:checksyntax#defs#php#args ............................ |g:checksyntax#defs#php#args|
+        g:checksyntax#defs#phpcs#cmd ............................. |g:checksyntax#defs#phpcs#cmd|
+        g:checksyntax#defs#phpcs#args ............................ |g:checksyntax#defs#phpcs#args|
         g:checksyntax#defs#haxe#haxe ........................... |g:checksyntax#defs#haxe#haxe|
         g:checksyntax#defs#haxe#hxml_files ..................... |g:checksyntax#defs#haxe#hxml_files|
         checksyntax#defs#haxe#Gen .............................. |checksyntax#defs#haxe#Gen()|
@@ -500,6 +502,14 @@ g:checksyntax#defs#php#args    (default: '-l -n -d display_errors=1 -d error_log
     display_errors is On because of the php.ini. By default, the 
     setting in php.ini is ignored ("-n" command-line flag).
 
+
+                                                    *g:checksyntax#defs#phpcs#cmd*
+g:checksyntax#defs#phpcs#cmd     (default: 'phpcs')
+
+                                                    *g:checksyntax#defs#phpcs#args*
+g:checksyntax#defs#php#args    (default: '')
+   For passing arguments into phpcs. Can be used to set options such 
+   as '--standard=PSR2 --ignore=foo.php'
 
 ========================================================================
 autoload/checksyntax/defs/haxe.vim~


### PR DESCRIPTION
New globals for configuration:
  `g:checksyntax#defs#phpcs#cmd`
  `g:checksyntax#defs#phpcs#args`